### PR TITLE
Fix JSON for Fade Effect in default.json

### DIFF
--- a/src/templates/default.json
+++ b/src/templates/default.json
@@ -119,7 +119,10 @@
 				"pagination": {
 					"el": ".swiper-pagination",
 					"clickable": true
-				}
+				},
+				"fadeEffect": {
+			    "crossFade": true
+			  },
 			}
 		},
 		"Coverflow": {


### PR DESCRIPTION
The fadeEffect object is missing from the FADE effect that is needed to work. I've added, Kindly accept this pull request, and release a new update on `WP.org`